### PR TITLE
gemspec: bump activesupport version to ~> 6.0

### DIFF
--- a/iiif-image-api.gemspec
+++ b/iiif-image-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '<= 6'
+  spec.add_dependency 'activesupport', '~> 6.0'
 
   spec.add_development_dependency 'bundler', "~> 1.10"
   spec.add_development_dependency 'rake', "~> 10.0"

--- a/iiif-image-api.gemspec
+++ b/iiif-image-api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 6.0'
 
-  spec.add_development_dependency 'bundler', "~> 1.10"
+  spec.add_development_dependency 'bundler', "~> 2.1.4"
   spec.add_development_dependency 'rake', "~> 10.0"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
We upgraded an app that uses `riiif` to Rails 6, however, that breaks (only in production) because riiif requires the iiif-image-api which requires exactly 6.0.  This PR bumps the gem to ~> 6.0 to solve that problem.  It would be better if the gem dependency also included the minimum required version.