### PR TITLE
Rails 6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ notifications:
   email: false
 
 rvm:
-  - 2.4.2
+  - 2.6.3
 
 sudo: false
 language: ruby

--- a/iiif-image-api.gemspec
+++ b/iiif-image-api.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'iiif/image/version'
 
@@ -18,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '<= 6'
+  spec.add_dependency 'activesupport'
 
-  spec.add_development_dependency 'bundler', "~> 1.10"
-  spec.add_development_dependency 'rake', "~> 10.0"
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
`riiif` still depends on this gem so it needs its Rails requirement loosed for downstream applications.