### PR TITLE
Add webp as a valid output format

### DIFF
--- a/lib/iiif/image/services/option_decoder.rb
+++ b/lib/iiif/image/services/option_decoder.rb
@@ -3,7 +3,7 @@
 module IIIF::Image
   # Decodes the URL parameters into a Transformation object
   class OptionDecoder
-    OUTPUT_FORMATS = %w(jpg png).freeze
+    OUTPUT_FORMATS = %w(webp jpg png).freeze
     QUALITY_OPTIONS = %w(bitonal gray grey default color)
 
     # a helper method for instantiating the OptionDecoder


### PR DESCRIPTION
Webp is a well supported format that performs superior to jpg